### PR TITLE
Remove subpaths to allow config reload

### DIFF
--- a/pgbouncer/Chart.yaml
+++ b/pgbouncer/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: PgBouncer chart
 home: https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer
 name: pgbouncer
-version: 2.0.7
+version: 2.0.8

--- a/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -48,7 +48,7 @@ unix_socket_dir = var/run/postgresql
 
 auth_type = {{ .Values.settings.auth_type }}
 ;auth_file = /8.0/main/global/pg_auth
-auth_file = /etc/pgbouncer/userlist.txt
+auth_file = /etc/pgbouncer.d/userlist.txt
 ;auth_hba_file =
 
 {{- with .Values.settings.auth_query }}

--- a/pgbouncer/templates/deployment-pgbouncer.yaml
+++ b/pgbouncer/templates/deployment-pgbouncer.yaml
@@ -62,9 +62,15 @@ spec:
         - name: userssecret
           secret:
             secretName: {{ template "pgbouncer.usersSecretName" . }}
+            items:
+              - key: {{ template "pgbouncer.usersSecretKey" . }}
+                path: userlist.txt
         - name: config
           configMap:
             name: {{ template "pgbouncer.fullname" . }}-config
+            items:
+              - key: pgbouncer.ini
+                path: pgbouncer.ini
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -89,12 +95,10 @@ spec:
                 command: ["/bin/sh","-c","sleep 5"]
           volumeMounts:
             - name: userssecret
-              subPath: {{ template "pgbouncer.usersSecretKey" . }}
-              mountPath: /etc/pgbouncer/userlist.txt
+              mountPath: /etc/pgbouncer.d
               readOnly: true
             - name: config
-              subPath: pgbouncer.ini
-              mountPath: /etc/pgbouncer/pgbouncer.ini
+              mountPath: /etc/pgbouncer
               readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This PR removes subpaths in volume mounts so that changes to config maps are available for the pod. This then allows us to issue `RELOAD` commands to pgbouncer.

See the note at https://kubernetes.io/docs/concepts/storage/volumes/#configmap
> A container using a ConfigMap as a subPath volume mount will not receive ConfigMap updates.

Same goes for secrets.